### PR TITLE
Fix PHP 8.1+ “optional-before-required” parameter order in ProvisioningService/LoginController

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -237,7 +237,7 @@ class LoginController extends Controller {
 			}
 		}
 
-		$user = $this->provisioningService->provisionUser($profileData, $user, $mappedGroupIDs);
+		$user = $this->provisioningService->provisionUser($profileData, $mappedGroupIDs, $user);
 
 		if (!$this->authenticateUser($user)) {
 			return $this->buildErrorTemplateResponse(

--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -24,7 +24,7 @@ class ProvisioningService {
 
 	}
 
-	public function provisionUser(object $profileData, ?IUser $existingUser = null, array $mappedGroupIDs): ?IUser {
+	public function provisionUser(object $profileData, array $mappedGroupIDs, ?IUser $existingUser = null): ?IUser {
 		$user = $existingUser;
 		if (!$user) {
 			$userId = "hitobito_$profileData->id";


### PR DESCRIPTION
**What**
- Reorder method signature in `ProvisioningService::provisionUser(object $profileData, array $mappedGroupIDs, ?IUser $existingUser = null)`.
- Adjust call site in `LoginController` (~line 240): `provisionUser($profile, $mappedGroupIDs, $existingUser)`.
- No logic change.

**Why**
- On PHP 8.0 this signature pattern is deprecated; on PHP 8.1+ the engine treats the optional-before-required parameter as required.  
- In this app it surfaces as a runtime error message in the logs:  
  “Optional parameter $existingUser declared before required parameter $mappedGroupIDs…”.  
- This change removes the deprecation/error source.

**Applies to**
- Required on any deployment running PHP ≥ 8.1.
- Practically mandatory for Nextcloud 30+ (these releases require PHP ≥ 8.1); also affects earlier NC versions if operated on PHP ≥ 8.1.

**Compatibility**
- Internal method; only this app’s call sites adjusted.
- No data or schema changes.

**References**
- PHP manual: [Optional parameters specified before required parameters](https://www.php.net/manual/en/migration81.incompatible.php) (PHP 8.0 deprecation, 8.1 error).
